### PR TITLE
reduce raciness by copying nodes in kRandomNodes

### DIFF
--- a/util.go
+++ b/util.go
@@ -149,6 +149,16 @@ OUTER:
 		// Append the node
 		kNodes = append(kNodes, node)
 	}
+	kNodeStorage := make([]nodeState, len(kNodes))
+	// Copy the contents of the node pointers out to local storage, and
+	// return pointers to that, so we avoid races.
+	for i, node := range kNodes {
+		kNodeStorage[i] = *node
+		metaCopy := make([]byte, len(node.Meta))
+		copy(metaCopy, node.Meta)
+		kNodeStorage[i].Meta = metaCopy
+		kNodes[i] = &kNodeStorage[i]
+	}
 	return kNodes
 }
 


### PR DESCRIPTION
While kRandomNodes is usually called while the node list mutex is
locked, the resulting *node pointers are frequently dereferenced
without the mutex being locked. Some things, like AliveNode(),
modify the state of an existing node in a node map, which means
that access to that node's contents elsewhere is a race.
One solution is to ensure that we're copying these states out.
(The other would be for AliveNode and the like to replace the
object in the node map with a new one.)